### PR TITLE
feat: default card for when no meetups scheduled

### DIFF
--- a/src/components/meetups.js
+++ b/src/components/meetups.js
@@ -27,7 +27,27 @@ export default function Meetups() {
       })
   }
 
-  if (meetups) {
+  if (meetups == null) {
+    return (
+      <Card className={classes.card}>
+        <div className={classes.cardDetails}>
+          <CardContent>
+            <Typography component="p">Loading...</Typography>
+          </CardContent>
+        </div>
+      </Card>
+    )
+  } else if (meetups.length == 0) {
+    return (
+      <Card className={classes.card}>
+        <div className={classes.cardDetails}>
+          <CardContent>
+            <Typography component="p">No meetups currently scheduled.</Typography>
+          </CardContent>
+        </div>
+      </Card>
+    )
+  } else {
     return meetups.map(meetup => (
       <CardActionArea
         key={meetup.created}
@@ -55,7 +75,5 @@ export default function Meetups() {
         </Card>
       </CardActionArea>
     ))
-  } else {
-    return <h3>Loading...</h3>
   }
 }


### PR DESCRIPTION
A loading card is shown before being replaced by one of two; either a card that "No meetups currently scheduled." when API returns empty, or there are one or more meetups and default behavior is unaffected. 

Manually tested with a couple of groups from meetup.com to verify behaviour in a local development build.

closes https://github.com/swfl-coders/website/issues/36