### PR TITLE
Added instructions for resolving build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
 
    **NOTE:** _You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
 
+   **NOTE:**  _If you are receiving build errors after running _`npm install`_, your environment may have to be setup to build popular native Node.js modules that Gatsby uses. To learn more about setting up your build environment for your system, read the documentation under the **Additional Guides** section on [Gatsby](https://www.gatsbyjs.com/docs/how-to/local-development/#additional)._
+
 4. **Contribute to this project**
 
    To contribute, please read our [contributing guidelines](CONTRIBUTE.md)


### PR DESCRIPTION
Hi team,

While following the instructions in cloning and running this project, I came across some issues that your Readme doesn't cover for first time Gatsby users. I updated your Readme to include some resources to help developers resolve issues on the environment Gatsby is trying to run on.

For example, I couldn't run ```npm install``` because I apparently didn't have Python 2.7 installed. I followed the guides that I provided in this commit to setup my Windows environment to run this project.